### PR TITLE
Downgrade failures to set archives and archive invalidation to warnings

### DIFF
--- a/src/gamebryo/gamebryobsainvalidation.cpp
+++ b/src/gamebryo/gamebryobsainvalidation.cpp
@@ -60,7 +60,7 @@ bool GamebryoBSAInvalidation::prepareProfile(MOBase::IProfile *profile)
     || wcstol(setting, nullptr, 10) != 1) {
     dirty = true;
     if (!MOBase::WriteRegistryValue(L"Archive", L"bInvalidateOlderFiles", L"1", iniFilePath.toStdWString().c_str())) {
-      throw MOBase::MyException(QObject::tr("failed to activate BSA invalidation in \"%1\" (errorcode %2)").arg(m_IniFileName, ::GetLastError()));
+      qWarning("failed to activate BSA invalidation in \"%s\"", qUtf8Printable(m_IniFileName));
     }
   }
 
@@ -93,7 +93,7 @@ bool GamebryoBSAInvalidation::prepareProfile(MOBase::IProfile *profile)
       || wcscmp(setting, L"") != 0) {
       dirty = true;
       if (!MOBase::WriteRegistryValue(L"Archive", L"SInvalidationFile", L"", iniFilePath.toStdWString().c_str())) {
-        throw MOBase::MyException(QObject::tr("failed to activate BSA invalidation in \"%1\" (errorcode %2)").arg(m_IniFileName, ::GetLastError()));
+        qWarning("failed to activate BSA invalidation in \"%s\"", qUtf8Printable(m_IniFileName));
       }
     }
   } else {
@@ -119,7 +119,7 @@ bool GamebryoBSAInvalidation::prepareProfile(MOBase::IProfile *profile)
       || wcscmp(setting, L"ArchiveInvalidation.txt") != 0) {
       dirty = true;
       if (!MOBase::WriteRegistryValue(L"Archive", L"SInvalidationFile", L"ArchiveInvalidation.txt", iniFilePath.toStdWString().c_str())) {
-        throw MOBase::MyException(QObject::tr("failed to activate BSA invalidation in \"%1\" (errorcode %2)").arg(m_IniFileName, ::GetLastError()));
+        qWarning("failed to activate BSA invalidation in \"%s\"", qUtf8Printable(m_IniFileName));
       }
     }
   }

--- a/src/gamebryo/gamebryodataarchives.cpp
+++ b/src/gamebryo/gamebryodataarchives.cpp
@@ -33,7 +33,7 @@ QStringList GamebryoDataArchives::getArchivesFromKey(const QString &iniFile, con
 void GamebryoDataArchives::setArchivesToKey(const QString &iniFile, const QString &key, const QString &value)
 {
   if (!MOBase::WriteRegistryValue(L"Archive", key.toStdWString().c_str(), value.toStdWString().c_str(), iniFile.toStdWString().c_str())) {
-    throw MOBase::MyException(QObject::tr("failed to set archive key in %1 (errorcode %2)").arg(iniFile).arg(errno));
+    qWarning("failed to set archives in \"%s\"", qUtf8Printable(iniFile));
   }
 }
 


### PR DESCRIPTION
Some users value the ability to keep INI files as read-only and do not
want to be constantly nagged to clear the read-only status. This allows
them to mostly ignore the nags.