### PR TITLE
Optimize read

### DIFF
--- a/src/creation/creationgameplugins.cpp
+++ b/src/creation/creationgameplugins.cpp
@@ -104,9 +104,7 @@ void CreationGamePlugins::writePluginList(const IPluginList *pluginList,
                             "and rename them."));
   }
 
-  if (file.commitIfDifferent(m_LastSaveHash[filePath])) {
-    qDebug("%s saved", qUtf8Printable(QDir::toNativeSeparators(filePath)));
-  }
+  file.commitIfDifferent(m_LastSaveHash[filePath]);
 }
 
 QStringList CreationGamePlugins::readPluginList(MOBase::IPluginList *pluginList)


### PR DESCRIPTION
removed a bunch of `"{} saved"` logs
`readLoadOrderList()` now uses `forEachLineInFile()` from uibase, same functionality but faster