### PR TITLE
Add getProductVersion() method.

### DIFF
--- a/src/gamebryo/gamegamebryo.cpp
+++ b/src/gamebryo/gamegamebryo.cpp
@@ -122,7 +122,17 @@ bool GameGamebryo::looksValid(QDir const &path) const
 
 QString GameGamebryo::gameVersion() const
 {
-  return getVersion(binaryName());
+  // We try the file version, but if it looks invalid (starts with the fallback
+  // version), we look the product version instead. If the product version is 
+  // not empty, we use it.
+  QString version = getVersion(binaryName());
+  if (version.startsWith(FALLBACK_GAME_VERSION)) {
+    QString pversion = getProductVersion(binaryName());
+    if (!pversion.isEmpty()) {
+      version = pversion;
+    }
+  }
+  return version;
 }
 
 QString GameGamebryo::getLauncherName() const

--- a/src/gamebryo/gamegamebryo.h
+++ b/src/gamebryo/gamegamebryo.h
@@ -80,6 +80,7 @@ protected:
   QString myGamesPath() const;
   QString selectedVariant() const;
   QString getVersion(QString const &program) const;
+  QString getProductVersion(QString const& program) const;
   WORD getArch(QString const &program) const;
 
   static QString localAppFolder();

--- a/src/gamebryo/gamegamebryo.h
+++ b/src/gamebryo/gamegamebryo.h
@@ -31,6 +31,13 @@ class GameGamebryo : public MOBase::IPluginGame,
   friend class GamebryoSaveGameInfo;
   friend class GamebryoSaveGameInfoWidget;
 
+  /**
+   * Some Bethesda games do not have a valid file version but a valid product
+   * version. If the file version starts with FALLBACK_GAME_VERSION, the product
+   * version will be tried.
+   */
+  static constexpr const char* FALLBACK_GAME_VERSION = "1.0.0";
+
 public:
 
   GameGamebryo();


### PR DESCRIPTION
This is a small PR that adds a `getProductVersion()` in `GameGamebryo`. Some game executables have "wrong" file version (e.g., `SkyrimSE.exe`), so this might be used for those game to override `gameVersion()`.

I did not want to change `getVersion` to always use product version because for some games there are minor differences (e.g., `Morrowind.exe` file version is 1.6.0.1820 while product version is 1.6.1820), and it breaks SKSE (`skse_loader.exe` product version is `0, 2, 0, 17`).

Maybe `gameVersion` could be changed to alway use `getProductVersion`, but since I don't have all Bethesda's game currently installed, I cannot check.

![image](https://user-images.githubusercontent.com/2393288/82243221-81ecf180-993f-11ea-91e5-cae3c9876fcf.png)
