### PR TITLE
Translation for gamebryo plugins

### DIFF
--- a/src/creation/CMakeLists.txt
+++ b/src/creation/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 project(game_creation)
 set(project_type lib)
 set(enable_warnings OFF)
+set(create_translations OFF)
 
 # appveyor does not build modorganizer in its standard location, so use
 # DEPENDENCIES_DIR to find cmake_common

--- a/src/game_gamebryo_en.ts
+++ b/src/game_gamebryo_en.ts
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+<context>
+    <name>GamebryoModDataContent</name>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="12"/>
+        <source>Plugins (ESP/ESM/ESL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="13"/>
+        <source>Optional Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="14"/>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="15"/>
+        <source>Meshes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="16"/>
+        <source>Bethesda Archive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="17"/>
+        <source>Scripts (Papyrus)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="18"/>
+        <source>Script Extender Plugin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="19"/>
+        <source>Script Extender Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="20"/>
+        <source>SkyProc Patcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="21"/>
+        <source>Sound or Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="22"/>
+        <source>Textures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="23"/>
+        <source>MCM Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="24"/>
+        <source>INI Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="25"/>
+        <source>ModGroup Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GamebryoSaveGameInfoWidget</name>
+    <message>
+        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="39"/>
+        <source>Save #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="51"/>
+        <source>Character</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="63"/>
+        <source>Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="75"/>
+        <source>Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="87"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="73"/>
+        <source>Has Script Extender Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="78"/>
+        <source>Missing ESPs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="111"/>
+        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="149"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="117"/>
+        <source>Missing ESLs</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="creation/creationgameplugins.cpp" line="101"/>
+        <location filename="gamebryo/gamebryogameplugins.cpp" line="129"/>
+        <source>Some of your plugins have invalid names! These plugins can not be loaded by the game. Please see mo_interface.log for a list of affected plugins and rename them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegame.cpp" line="92"/>
+        <source>failed to open %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamebryosavegame.cpp" line="102"/>
+        <source>wrong file format - expected %1 got %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamegamebryo.cpp" line="275"/>
+        <source>failed to query registry path (preflight): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryo/gamegamebryo.cpp" line="282"/>
+        <source>failed to query registry path (read): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Instead of duplicating the gamebryo strings in all game plugins, this adds a `.ts` file for gamebryo itself, which will be merged with game plugin-specific strings by unimake when generating translations.

Also turned off translations for the creation project, they're the same as gamebryo.