### PR TITLE
Mismatched lower/upper case

### DIFF
--- a/src/gamebryo/gamebryogameplugins.cpp
+++ b/src/gamebryo/gamebryogameplugins.cpp
@@ -147,11 +147,11 @@ QStringList GamebryoGamePlugins::readLoadOrderList(
 
   std::set<QString> pluginLookup;
   for (auto&& name : pluginNames) {
-    pluginLookup.insert(name);
+    pluginLookup.insert(name.toLower());
   }
 
   const auto b = MOBase::forEachLineInFile(filePath, [&](QString s) {
-    if (!pluginLookup.contains(s)) {
+    if (!pluginLookup.contains(s.toLower())) {
       pluginLookup.insert(s);
       pluginNames.push_back(std::move(s));
     }


### PR DESCRIPTION
`forEachLineInFile()` used to return lowercase strings, which would not match the names in `pluginLookup`. This would end up adding the plugins in the list twice, creating all sorts of problems down the line, such as bad priorities.

`forEachLineInFile()` has now changed in https://github.com/ModOrganizer2/modorganizer-uibase/pull/72 to return the strings as-is. Both gamebryo and skyrimSE have been updated.