### PR TITLE
My Games path is sometimes broken

### DIFF
--- a/src/gamebryo/gamegamebryo.cpp
+++ b/src/gamebryo/gamegamebryo.cpp
@@ -35,7 +35,11 @@ GameGamebryo::GameGamebryo()
 void GameGamebryo::detectGame()
 {
   m_GamePath = identifyGamePath();
+
   m_MyGamesPath = determineMyGamesPath(gameShortName());
+  if (m_MyGamesPath.isEmpty()) {
+    m_MyGamesPath = determineMyGamesPath(gameName());
+  }
 }
 
 bool GameGamebryo::init(MOBase::IOrganizer *moInfo)
@@ -340,6 +344,11 @@ QString GameGamebryo::determineMyGamesPath(const QString &gameName)
   if (result.isEmpty()
     || !QFileInfo(result + "/My Games/" + gameName).exists()) {
     result = getSpecialPath("Personal");
+  }
+
+  if (result.isEmpty()
+    || !QFileInfo(result + "/My Games/" + gameName).exists()) {
+    return {};
   }
 
   return result + "/My Games/" + gameName;


### PR DESCRIPTION
Some games use the short name, some use the long name, so try both. `determineMyGamesPath()` didn't handle errors very well, and it still doesn't, but it should work for now.