### PR TITLE
WIP: Update following cmake_common changes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,12 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(game_gamebryo)
-set(project_type lib)
-set(enable_warnings OFF)
-
 if(DEFINED DEPENDENCIES_DIR)
-	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/project.cmake)
+	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/mo2.cmake)
 else()
-	include(../cmake_common/project.cmake)
+	include(${CMAKE_CURRENT_LIST_DIR}/../cmake_common/mo2.cmake)
 endif()
-add_subdirectory(src/gamebryo)
 
-# note that this also creates a project
+project(game_gamebryo)
+
+add_subdirectory(src/gamebryo)
 add_subdirectory(src/creation)

--- a/src/creation/CMakeLists.txt
+++ b/src/creation/CMakeLists.txt
@@ -1,18 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(game_creation)
-set(project_type lib)
-set(enable_warnings OFF)
-set(create_translations OFF)
-
-# appveyor does not build modorganizer in its standard location, so use
-# DEPENDENCIES_DIR to find cmake_common
-if(DEFINED DEPENDENCIES_DIR)
-	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/project.cmake)
-	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/src.cmake)
-else()
-	include(../../../cmake_common/project.cmake)
-	include(../../../cmake_common/src.cmake)
-endif()
-
-requires_project(game_gamebryo game_features)
+add_library(game_creation STATIC)
+mo2_configure_library(game_creation
+	WARNINGS OFF
+	PUBLIC_DEPENDS uibase
+	PRIVATE_DEPENDS lz4)
+target_link_libraries(game_creation PUBLIC game_gamebryo)
+mo2_install_target(game_creation)

--- a/src/gamebryo/CMakeLists.txt
+++ b/src/gamebryo/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
-# appveyor does not build modorganizer in its standard location, so use
-# DEPENDENCIES_DIR to find cmake_common
-if(DEFINED DEPENDENCIES_DIR)
-	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/src.cmake)
-else()
-	include(../../../cmake_common/src.cmake)
-endif()
 
-requires_project(game_features)
+add_library(game_gamebryo STATIC)
+mo2_configure_library(game_gamebryo
+	WARNINGS OFF
+	TRANSLATIONS ON
+	AUTOMOC ON
+	PUBLIC_DEPENDS uibase
+	PRIVATE_DEPENDS lz4)
+mo2_install_target(game_gamebryo)

--- a/src/gamebryo/game_gamebryo_en.ts
+++ b/src/gamebryo/game_gamebryo_en.ts
@@ -4,77 +4,77 @@
 <context>
     <name>GamebryoModDataContent</name>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="12"/>
+        <location filename="gamebryomoddatacontent.cpp" line="12"/>
         <source>Plugins (ESP/ESM/ESL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="13"/>
+        <location filename="gamebryomoddatacontent.cpp" line="13"/>
         <source>Optional Plugins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="14"/>
+        <location filename="gamebryomoddatacontent.cpp" line="14"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="15"/>
+        <location filename="gamebryomoddatacontent.cpp" line="15"/>
         <source>Meshes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="16"/>
+        <location filename="gamebryomoddatacontent.cpp" line="16"/>
         <source>Bethesda Archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="17"/>
+        <location filename="gamebryomoddatacontent.cpp" line="17"/>
         <source>Scripts (Papyrus)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="18"/>
+        <location filename="gamebryomoddatacontent.cpp" line="18"/>
         <source>Script Extender Plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="19"/>
+        <location filename="gamebryomoddatacontent.cpp" line="19"/>
         <source>Script Extender Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="20"/>
+        <location filename="gamebryomoddatacontent.cpp" line="20"/>
         <source>SkyProc Patcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="21"/>
+        <location filename="gamebryomoddatacontent.cpp" line="21"/>
         <source>Sound or Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="22"/>
+        <location filename="gamebryomoddatacontent.cpp" line="22"/>
         <source>Textures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="23"/>
+        <location filename="gamebryomoddatacontent.cpp" line="23"/>
         <source>MCM Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="24"/>
+        <location filename="gamebryomoddatacontent.cpp" line="24"/>
         <source>INI Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="25"/>
+        <location filename="gamebryomoddatacontent.cpp" line="25"/>
         <source>FaceGen Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryomoddatacontent.cpp" line="26"/>
+        <location filename="gamebryomoddatacontent.cpp" line="26"/>
         <source>ModGroup Files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -82,48 +82,48 @@
 <context>
     <name>GamebryoSaveGameInfoWidget</name>
     <message>
-        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="39"/>
+        <location filename="gamebryosavegameinfowidget.ui" line="39"/>
         <source>Save #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="51"/>
+        <location filename="gamebryosavegameinfowidget.ui" line="51"/>
         <source>Character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="63"/>
+        <location filename="gamebryosavegameinfowidget.ui" line="63"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="75"/>
+        <location filename="gamebryosavegameinfowidget.ui" line="75"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryosavegameinfowidget.ui" line="87"/>
+        <location filename="gamebryosavegameinfowidget.ui" line="87"/>
         <source>Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="72"/>
+        <location filename="gamebryosavegameinfowidget.cpp" line="72"/>
         <source>Has Script Extender Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="77"/>
+        <location filename="gamebryosavegameinfowidget.cpp" line="77"/>
         <source>Missing ESPs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="110"/>
-        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="148"/>
+        <location filename="gamebryosavegameinfowidget.cpp" line="110"/>
+        <location filename="gamebryosavegameinfowidget.cpp" line="148"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamebryosavegameinfowidget.cpp" line="116"/>
+        <location filename="gamebryosavegameinfowidget.cpp" line="116"/>
         <source>Missing ESLs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -131,33 +131,33 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="gamebryo/gamebryogameplugins.cpp" line="129"/>
-        <source>Some of your plugins have invalid names! These plugins can not be loaded by the game. Please see mo_interface.log for a list of affected plugins and rename them.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="gamebryo/gamebryosavegame.cpp" line="47"/>
-        <source>%1, #%2, Level %3, %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="gamebryo/gamebryosavegame.cpp" line="97"/>
-        <source>failed to open %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="gamebryo/gamebryosavegame.cpp" line="107"/>
-        <source>wrong file format - expected %1 got %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="gamebryo/gamegamebryo.cpp" line="323"/>
+        <location filename="gamegamebryo.cpp" line="323"/>
         <source>failed to query registry path (preflight): %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamebryo/gamegamebryo.cpp" line="330"/>
+        <location filename="gamegamebryo.cpp" line="330"/>
         <source>failed to query registry path (read): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryosavegame.cpp" line="47"/>
+        <source>%1, #%2, Level %3, %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryosavegame.cpp" line="97"/>
+        <source>failed to open %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryosavegame.cpp" line="107"/>
+        <source>wrong file format - expected %1 got %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamebryogameplugins.cpp" line="129"/>
+        <source>Some of your plugins have invalid names! These plugins can not be loaded by the game. Please see mo_interface.log for a list of affected plugins and rename them.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
See https://github.com/ModOrganizer2/cmake_common/pull/18

Doing this PR now because there is a change here: the `.ts` file is now generated under `src/gamebryo` and not directly under `src/`, so the transifex path needs to be updated.

I will need to check if this is fine for the rest of the stuff but it should be, if it's not it's a simple fix in `cmake_common` but this feels cleaner that way.