### PR TITLE
Improve Starfield save performance

### DIFF
--- a/src/gamebryo/gamebryosavegame.h
+++ b/src/gamebryo/gamebryosavegame.h
@@ -118,6 +118,7 @@ protected:
     template <typename T>
     void readQDataStream(QDataStream& data, T& value);
     void readQDataStream(QDataStream& data, void* buff, std::size_t length);
+    void qDataStreamSkip(QDataStream& data, std::size_t length);
 
     /* Reads RGB image from save
      * Assumes picture dimentions come immediately before the save

--- a/src/gamebryo/gamebryosavegame.h
+++ b/src/gamebryo/gamebryosavegame.h
@@ -170,7 +170,7 @@ protected:
 
     void readQDataStream(QDataStream& data, void* buff, std::size_t length);
 
-    void qDataStreamSkip(QDataStream& data, std::size_t length);
+    void skipQDataStream(QDataStream& data, std::size_t length);
   };
 
   void setCreationTime(_SYSTEMTIME const& time);

--- a/src/gamebryo/gamebryosavegame.h
+++ b/src/gamebryo/gamebryosavegame.h
@@ -115,6 +115,10 @@ protected:
 
     void read(void* buff, std::size_t length);
 
+    template <typename T>
+    void readQDataStream(QDataStream& data, T& value);
+    void readQDataStream(QDataStream& data, void* buff, std::size_t length);
+
     /* Reads RGB image from save
      * Assumes picture dimentions come immediately before the save
      */
@@ -129,6 +133,9 @@ protected:
 
     /* uncompress the begining of the compressed block */
     bool openCompressedData(int bytesToIgnore = 0);
+
+    /* read the next compressed block */
+    bool readNextChunk();
 
     /* frees the uncompressed block */
     void closeCompressedData();
@@ -154,6 +161,8 @@ protected:
 
   private:
     QFile m_File;
+    uint64_t m_NextChunk;
+    uint64_t m_UncompressedSize;
     bool m_HasFieldMarkers;
     StringType m_PluginString;
     QDataStream* m_Data;

--- a/src/gamebryo/gamebryosavegame.h
+++ b/src/gamebryo/gamebryosavegame.h
@@ -115,11 +115,6 @@ protected:
 
     void read(void* buff, std::size_t length);
 
-    template <typename T>
-    void readQDataStream(QDataStream& data, T& value);
-    void readQDataStream(QDataStream& data, void* buff, std::size_t length);
-    void qDataStreamSkip(QDataStream& data, std::size_t length);
-
     /* Reads RGB image from save
      * Assumes picture dimentions come immediately before the save
      */
@@ -168,6 +163,14 @@ protected:
     StringType m_PluginString;
     QDataStream* m_Data;
     uint16_t m_CompressionType = 0;
+
+  private:
+    template <typename T>
+    void readQDataStream(QDataStream& data, T& value);
+
+    void readQDataStream(QDataStream& data, void* buff, std::size_t length);
+
+    void qDataStreamSkip(QDataStream& data, std::size_t length);
   };
 
   void setCreationTime(_SYSTEMTIME const& time);


### PR DESCRIPTION
- Decompress data one chunk at a time
- Track next chunk location and total size
- If end of stream reached during read, attempt to decompress another chunk and continue from new bytes