### PR TITLE
Add toggle for using fromLocal8Bit

### DIFF
--- a/src/gamebryo/gamebryosavegame.cpp
+++ b/src/gamebryo/gamebryosavegame.cpp
@@ -163,8 +163,7 @@ void GamebryoSaveGame::FileWrapper::skipQDataStream(QDataStream& data,
   }
 }
 
-template <>
-void GamebryoSaveGame::FileWrapper::read(QString& value)
+void GamebryoSaveGame::FileWrapper::read(QString& value, bool isUtf8)
 {
   if (m_CompressionType == 0) {
     unsigned short length;
@@ -223,11 +222,20 @@ void GamebryoSaveGame::FileWrapper::read(QString& value)
       m_Data->skipRawData(1);
     }
 
-    value = QString::fromUtf8(buffer.constData());
+    if (isUtf8)
+      value = QString::fromUtf8(buffer.constData());
+    else
+      value = QString::fromLocal8Bit(buffer.constData());
   } else {
     MOBase::log::warn("Please create an issue on the MO github labeled \"Found unknown "
                       "Compressed\" with your savefile attached");
   }
+}
+
+template <>
+void GamebryoSaveGame::FileWrapper::read<QString>(QString& value)
+{
+  read(value, true);
 }
 
 void GamebryoSaveGame::FileWrapper::read(void* buff, std::size_t length)

--- a/src/gamebryo/gamebryosavegame.cpp
+++ b/src/gamebryo/gamebryosavegame.cpp
@@ -200,7 +200,10 @@ void GamebryoSaveGame::FileWrapper::read<QString>(QString& value)
       skip<char>();
     }
 
-    value = QString::fromUtf8(buffer.constData());
+    if (m_PluginStringFormat == StringFormat::UTF8)
+      value = QString::fromUtf8(buffer.constData());
+    else
+      value = QString::fromLocal8Bit(buffer.constData());
   } else if (m_CompressionType == 1 || m_CompressionType == 2) {
     unsigned short length;
     if (m_PluginString == StringType::TYPE_BSTRING ||

--- a/src/gamebryo/gamebryosavegame.h
+++ b/src/gamebryo/gamebryosavegame.h
@@ -64,8 +64,8 @@ public:
 
   enum StringFormat
   {
-      UTF8,
-      LOCAL8BIT
+    UTF8,
+    LOCAL8BIT
   };
 
 protected:
@@ -93,7 +93,7 @@ protected:
     void setPluginString(StringType);
 
     /** Set string format (utf-8, windows local 8 bit strings)
-    **/
+     **/
     void setPluginStringFormat(StringFormat);
 
     template <typename T>

--- a/src/gamebryo/gamebryosavegame.h
+++ b/src/gamebryo/gamebryosavegame.h
@@ -106,6 +106,11 @@ protected:
       }
     }
 
+    template <>
+    void read<QString>(QString& value);
+
+    void read(QString& value, bool isUtf8);
+
     void seek(unsigned long pos)
     {
       if (!m_File.seek(pos)) {
@@ -205,8 +210,5 @@ protected:
   // Fetch the field.
   virtual std::unique_ptr<DataFields> fetchDataFields() const = 0;
 };
-
-template <>
-void GamebryoSaveGame::FileWrapper::read<QString>(QString&);
 
 #endif  // GAMEBRYOSAVEGAME_H

--- a/src/gamebryo/gamebryosavegame.h
+++ b/src/gamebryo/gamebryosavegame.h
@@ -55,14 +55,14 @@ public:
 
   bool isLightEnabled() const { return m_LightEnabled; }
 
-  enum StringType
+  enum class StringType
   {
     TYPE_BZSTRING,
     TYPE_BSTRING,
     TYPE_WSTRING
   };
 
-  enum StringFormat
+  enum class StringFormat
   {
     UTF8,
     LOCAL8BIT

--- a/src/gamebryo/gamebryosavegame.h
+++ b/src/gamebryo/gamebryosavegame.h
@@ -62,6 +62,12 @@ public:
     TYPE_WSTRING
   };
 
+  enum StringFormat
+  {
+      UTF8,
+      LOCAL8BIT
+  };
+
 protected:
   friend class FileWrapper;
 
@@ -86,6 +92,10 @@ protected:
      **/
     void setPluginString(StringType);
 
+    /** Set string format (utf-8, windows local 8 bit strings)
+    **/
+    void setPluginStringFormat(StringFormat);
+
     template <typename T>
     void skip(int count = 1)
     {
@@ -108,8 +118,6 @@ protected:
 
     template <>
     void read<QString>(QString& value);
-
-    void read(QString& value, bool isUtf8);
 
     void seek(unsigned long pos)
     {
@@ -166,6 +174,7 @@ protected:
     uint64_t m_UncompressedSize;
     bool m_HasFieldMarkers;
     StringType m_PluginString;
+    StringFormat m_PluginStringFormat;
     QDataStream* m_Data;
     uint16_t m_CompressionType = 0;
 


### PR DESCRIPTION
- Some games use windows encoding for locality
- Allow toggling between loading utf-8 and local8bit, defaulting to utf-8 for backward compatibility