### PR TITLE
Plugin sorting updates

### DIFF
--- a/src/gamebryo/gamegamebryo.cpp
+++ b/src/gamebryo/gamegamebryo.cpp
@@ -72,11 +72,6 @@ QDir GameGamebryo::dataDirectory() const
   return gameDirectory().absoluteFilePath("data");
 }
 
-QMap<QString, QDir> GameGamebryo::secondaryDataDirectories() const
-{
-  return QMap<QString, QDir>();
-}
-
 void GameGamebryo::setGamePath(const QString& path)
 {
   m_GamePath = path;
@@ -106,11 +101,6 @@ GameGamebryo::listSaves(QDir folder) const
   return saves;
 }
 
-QStringList GameGamebryo::gameVariants() const
-{
-  return QStringList();
-}
-
 void GameGamebryo::setGameVariant(const QString& variant)
 {
   m_GameVariant = variant;
@@ -119,21 +109,6 @@ void GameGamebryo::setGameVariant(const QString& variant)
 QString GameGamebryo::binaryName() const
 {
   return gameShortName() + ".exe";
-}
-
-QStringList GameGamebryo::primarySources() const
-{
-  return {};
-}
-
-QStringList GameGamebryo::validShortNames() const
-{
-  return {};
-}
-
-QStringList GameGamebryo::CCPlugins() const
-{
-  return {};
 }
 
 MOBase::IPluginGame::LoadOrderMechanism GameGamebryo::loadOrderMechanism() const

--- a/src/gamebryo/gamegamebryo.h
+++ b/src/gamebryo/gamegamebryo.h
@@ -63,6 +63,7 @@ public:  // IPluginGame interface
   // executables
   // steamAPPId
   // primaryPlugins
+  virtual QStringList enabledPlugins() const override { return {}; }
   virtual QStringList gameVariants() const override;
   virtual void setGameVariant(const QString& variant) override;
   virtual QString binaryName() const override;

--- a/src/gamebryo/gamegamebryo.h
+++ b/src/gamebryo/gamegamebryo.h
@@ -56,23 +56,23 @@ public:  // IPluginGame interface
   virtual QIcon gameIcon() const override;
   virtual QDir gameDirectory() const override;
   virtual QDir dataDirectory() const override;
-  virtual QMap<QString, QDir> secondaryDataDirectories() const override;
+  // secondaryDataDirectories
   virtual void setGamePath(const QString& path) override;
   virtual QDir documentsDirectory() const override;
   virtual QDir savesDirectory() const override;
   // executables
   // steamAPPId
   // primaryPlugins
-  virtual QStringList enabledPlugins() const override { return {}; }
-  virtual QStringList gameVariants() const override;
+  // enabledPlugins
+  // gameVariants
   virtual void setGameVariant(const QString& variant) override;
   virtual QString binaryName() const override;
   // gameShortName
-  virtual QStringList primarySources() const override;
-  virtual QStringList validShortNames() const override;
+  // primarySources
+  // validShortNames
   // iniFiles
   // DLCPlugins
-  virtual QStringList CCPlugins() const override;
+  // CCPlugins
   virtual LoadOrderMechanism loadOrderMechanism() const override;
   virtual SortMechanism sortMechanism() const override;
   // nexusModOrganizerID


### PR DESCRIPTION
- Add enabledPlugins for core plugins which are enabled but NOT auto-loaded (may need to be written to plugins.txt or have an ambiguous load order position)
- General Starfield updates
  - Add enabledPlugins for "BlueprintShips-Starfield.esm"
  - Disable plugin management if sTestFile is in use (also applies to FO4)
  - Write the enabledPlugins to plugins.txt to enforce base game load order
  - Allow for LOOT sorting (dynamic based on settings)
- Incorporate enabledPlugins into force enabled plugins in plugin list
- Update various interface layers

TODO: Fix sort button to dynamically update if status changes
TODO: Auto refresh lists if the INI Editor is closed