### PR TITLE
Skip sorting DLC plugins

### DIFF
--- a/src/gamebryo/gamebryogameplugins.cpp
+++ b/src/gamebryo/gamebryogameplugins.cpp
@@ -168,17 +168,28 @@ QStringList GamebryoGamePlugins::readLoadOrderList(MOBase::IPluginList* pluginLi
 QStringList GamebryoGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
 {
   QStringList primary = organizer()->managedGame()->primaryPlugins();
+  QStringList dlc = organizer()->managedGame()->DLCPlugins();
+
   for (const QString& pluginName : primary) {
     if (pluginList->state(pluginName) != IPluginList::STATE_MISSING) {
       pluginList->setState(pluginName, IPluginList::STATE_ACTIVE);
     }
   }
+
   QStringList plugins = pluginList->pluginNames();
   QStringList pluginsClone(plugins);
+
   // Do not sort the primary plugins. Their load order should be locked as defined in
   // "primaryPlugins".
   for (const auto& plugin : pluginsClone) {
     if (primary.contains(plugin, Qt::CaseInsensitive))
+      plugins.removeAll(plugin);
+  }
+
+  // Do not sort dlc plugins, we want to retain the load order as defined by the dlc
+  // plugins list
+  for (const auto& plugin : pluginsClone) {
+    if (dlc.contains(plugin, Qt::CaseInsensitive))
       plugins.removeAll(plugin);
   }
 
@@ -244,7 +255,7 @@ QStringList GamebryoGamePlugins::readPluginList(MOBase::IPluginList* pluginList)
     }
   }
 
-  return primary + plugins;
+  return primary + dlc + plugins;
 }
 
 bool GamebryoGamePlugins::lightPluginsAreSupported()


### PR DESCRIPTION
# Motivations
Game plugins could benefit from providing their own preferred load order for DLC marked plugins. Fallout NV for example has a specific load order for it's DLC plugins that's been recommended by FNV oriented modding communities for 5+ years.

It's been attempted to "fix" this by moving all the DLC plugins into the primary plugins list, but that hard-locks the load order for those DLC plugins, which is against some of the MO2 teams principles

# Modifications
- Remove all DLC plugins from the plugin list that will be sorted by timestamp, pretty much the same as primary plugins

# Results
Game plugins DLC plugin list now implicitly defines the initial load order for DLC specific plugins

The initial load order for FNV for example before this change
![image](https://github.com/ModOrganizer2/modorganizer-game_gamebryo/assets/5809130/5a43125a-7d99-4e46-8d59-d084c08e89bc)

After, which matches https://github.com/ModOrganizer2/modorganizer-game_falloutnv/blob/master/src/gamefalloutnv.cpp#L278
![image](https://github.com/ModOrganizer2/modorganizer-game_gamebryo/assets/5809130/abfa4ef2-2977-4a73-99d7-c36752162b35)
