### PR TITLE
List valid saves if exception is raised for invalid save

### DIFF
--- a/src/gamebryo/gamebryosavegame.cpp
+++ b/src/gamebryo/gamebryosavegame.cpp
@@ -106,11 +106,13 @@ GamebryoSaveGame::FileWrapper::FileWrapper(QString const& filepath,
 
   QString id(fileID.data());
   if (expected != id) {
-    throw std::runtime_error(QObject::tr("wrong file format - expected %1 got %2")
-                                 .arg(expected)
-                                 .arg(id)
-                                 .toUtf8()
-                                 .constData());
+    throw std::runtime_error(
+        QObject::tr("wrong file format - expected %1 got \'%2\' for %3")
+            .arg(expected)
+            .arg(id)
+            .arg(filepath)
+            .toUtf8()
+            .constData());
   }
 }
 

--- a/src/gamebryo/gamegamebryo.cpp
+++ b/src/gamebryo/gamegamebryo.cpp
@@ -6,6 +6,7 @@
 #include "gamebryosavegame.h"
 #include "gameplugins.h"
 #include "iprofile.h"
+#include "log.h"
 #include "registry.h"
 #include "savegameinfo.h"
 #include "scopeguard.h"
@@ -95,7 +96,12 @@ GameGamebryo::listSaves(QDir folder) const
 
   std::vector<std::shared_ptr<const MOBase::ISaveGame>> saves;
   for (auto info : folder.entryInfoList(filters, QDir::Files)) {
-    saves.push_back(makeSaveGame(info.filePath()));
+    try {
+      saves.push_back(makeSaveGame(info.filePath()));
+    } catch (std::exception& e) {
+      MOBase::log::error("{}", e.what());
+      continue;
+    }
   }
 
   return saves;


### PR DESCRIPTION
This catches exceptions for invalid saves earlier so that any valid saves will still be displayed in the Saves tab. It also changes the exception message to include the path to the problematic save.