### PR TITLE
Use game plugin to obtain My Games path instead of passing it construction

### DIFF
--- a/src/gamebryo/gamebryodataarchives.cpp
+++ b/src/gamebryo/gamebryodataarchives.cpp
@@ -1,11 +1,18 @@
 #include "gamebryodataarchives.h"
-#include "registry.h"
+
 #include <Windows.h>
+
+#include <registry.h>
 #include <utility.h>
 
-GamebryoDataArchives::GamebryoDataArchives(const QDir& myGamesDir)
-    : m_LocalGameDir(myGamesDir.absolutePath())
-{}
+#include "gamegamebryo.h"
+
+GamebryoDataArchives::GamebryoDataArchives(const GameGamebryo* game) : m_Game{game} {}
+
+QDir GamebryoDataArchives::localGameDirectory() const
+{
+  return QDir(m_Game->myGamesPath()).absolutePath();
+}
 
 QStringList GamebryoDataArchives::getArchivesFromKey(const QString& iniFile,
                                                      const QString& key,

--- a/src/gamebryo/gamebryodataarchives.cpp
+++ b/src/gamebryo/gamebryodataarchives.cpp
@@ -9,6 +9,11 @@
 
 GamebryoDataArchives::GamebryoDataArchives(const GameGamebryo* game) : m_Game{game} {}
 
+QDir GamebryoDataArchives::gameDirectory() const
+{
+  return QDir(m_Game->gameDirectory()).absolutePath();
+}
+
 QDir GamebryoDataArchives::localGameDirectory() const
 {
   return QDir(m_Game->myGamesPath()).absolutePath();

--- a/src/gamebryo/gamebryodataarchives.h
+++ b/src/gamebryo/gamebryodataarchives.h
@@ -1,14 +1,17 @@
 #ifndef GAMEBRYODATAARCHIVES_H
 #define GAMEBRYODATAARCHIVES_H
 
-#include "dataarchives.h"
 #include <QDir>
+
+#include "dataarchives.h"
+
+class GameGamebryo;
 
 class GamebryoDataArchives : public MOBase::DataArchives
 {
 
 public:
-  GamebryoDataArchives(const QDir& myGamesDir);
+  GamebryoDataArchives(const GameGamebryo* game);
 
   virtual void addArchive(MOBase::IProfile* profile, int index,
                           const QString& archiveName) override;
@@ -16,13 +19,16 @@ public:
                              const QString& archiveName) override;
 
 protected:
-  QDir m_LocalGameDir;
+  QDir localGameDirectory() const;
+
   QStringList getArchivesFromKey(const QString& iniFile, const QString& key,
                                  int size = 256) const;
   void setArchivesToKey(const QString& iniFile, const QString& key,
                         const QString& value);
 
 private:
+  const GameGamebryo* m_Game;
+
   virtual void writeArchiveList(MOBase::IProfile* profile,
                                 const QStringList& before) = 0;
 };

--- a/src/gamebryo/gamebryodataarchives.h
+++ b/src/gamebryo/gamebryodataarchives.h
@@ -19,6 +19,7 @@ public:
                              const QString& archiveName) override;
 
 protected:
+  QDir gameDirectory() const;
   QDir localGameDirectory() const;
 
   QStringList getArchivesFromKey(const QString& iniFile, const QString& key,

--- a/src/gamebryo/gamebryolocalsavegames.cpp
+++ b/src/gamebryo/gamebryolocalsavegames.cpp
@@ -26,8 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "gamegamebryo.h"
 
-static const QString LocalSavesDummy = "__MO_Saves\\";
-
 GamebryoLocalSavegames::GamebryoLocalSavegames(const GameGamebryo* game,
                                                const QString& iniFileName)
     : m_Game{game}, m_IniFileName(iniFileName)
@@ -39,9 +37,14 @@ MappingType GamebryoLocalSavegames::mappings(const QDir& profileSaveDir) const
            true}};
 }
 
+QString GamebryoLocalSavegames::localSavesDummy() const
+{
+  return "__MO_Saves\\";
+}
+
 QDir GamebryoLocalSavegames::localSavesDirectory() const
 {
-  return QDir(m_Game->myGamesPath()).absoluteFilePath(LocalSavesDummy);
+  return QDir(m_Game->myGamesPath()).absoluteFilePath(localSavesDummy());
 }
 
 QDir GamebryoLocalSavegames::localGameDirectory() const
@@ -64,7 +67,7 @@ bool GamebryoLocalSavegames::prepareProfile(MOBase::IProfile* profile)
   GetPrivateProfileStringW(L"General", L"sLocalSavePath", L"SKIP_ME", currentPath,
                            MAX_PATH, iniFilePath.toStdWString().c_str());
   bool alreadyEnabled =
-      wcscmp(currentPath, LocalSavesDummy.toStdWString().c_str()) == 0;
+      wcscmp(currentPath, localSavesDummy().toStdWString().c_str()) == 0;
 
   // Get the current bUseMyGamesDirectory
   WCHAR currentMyGames[MAX_PATH];
@@ -92,7 +95,7 @@ bool GamebryoLocalSavegames::prepareProfile(MOBase::IProfile* profile)
                                  saveIni.toStdWString().c_str());
     }
     MOBase::WriteRegistryValue(L"General", L"sLocalSavePath",
-                               LocalSavesDummy.toStdWString().c_str(),
+                               localSavesDummy().toStdWString().c_str(),
                                iniFilePath.toStdWString().c_str());
     MOBase::WriteRegistryValue(L"General", L"bUseMyGamesDirectory", L"1",
                                iniFilePath.toStdWString().c_str());

--- a/src/gamebryo/gamebryolocalsavegames.cpp
+++ b/src/gamebryo/gamebryolocalsavegames.cpp
@@ -24,25 +24,38 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <string>
 #include <windows.h>
 
+#include "gamegamebryo.h"
+
 static const QString LocalSavesDummy = "__MO_Saves\\";
 
-GamebryoLocalSavegames::GamebryoLocalSavegames(const QDir& myGamesDir,
+GamebryoLocalSavegames::GamebryoLocalSavegames(const GameGamebryo* game,
                                                const QString& iniFileName)
-    : m_LocalSavesDir(myGamesDir.absoluteFilePath(LocalSavesDummy)),
-      m_LocalGameDir(myGamesDir.absolutePath()), m_IniFileName(iniFileName)
+    : m_Game{game}, m_IniFileName(iniFileName)
 {}
 
 MappingType GamebryoLocalSavegames::mappings(const QDir& profileSaveDir) const
 {
-  return {{profileSaveDir.absolutePath(), m_LocalSavesDir.absolutePath(), true, true}};
+  return {{profileSaveDir.absolutePath(), localSavesDirectory().absolutePath(), true,
+           true}};
+}
+
+QDir GamebryoLocalSavegames::localSavesDirectory() const
+{
+  return QDir(m_Game->myGamesPath()).absoluteFilePath(LocalSavesDummy);
+}
+
+QDir GamebryoLocalSavegames::localGameDirectory() const
+{
+  return QDir(m_Game->myGamesPath()).absolutePath();
 }
 
 bool GamebryoLocalSavegames::prepareProfile(MOBase::IProfile* profile)
 {
   bool enable = profile->localSavesEnabled();
 
-  QString basePath    = profile->localSettingsEnabled() ? profile->absolutePath()
-                                                        : m_LocalGameDir.absolutePath();
+  QString basePath    = profile->localSettingsEnabled()
+                            ? profile->absolutePath()
+                            : localGameDirectory().absolutePath();
   QString iniFilePath = basePath + "/" + m_IniFileName;
   QString saveIni     = profile->absolutePath() + "/" + "savepath.ini";
 
@@ -61,7 +74,7 @@ bool GamebryoLocalSavegames::prepareProfile(MOBase::IProfile* profile)
 
   // Create the __MO_Saves directory if local saves are enabled and it doesn't exist
   if (enable) {
-    QDir saves = QDir(m_LocalGameDir.absolutePath() + "/" + LocalSavesDummy);
+    QDir saves = localSavesDirectory();
     if (!saves.exists()) {
       saves.mkdir(".");
     }

--- a/src/gamebryo/gamebryolocalsavegames.h
+++ b/src/gamebryo/gamebryolocalsavegames.h
@@ -36,6 +36,13 @@ public:
   virtual bool prepareProfile(MOBase::IProfile* profile) override;
 
 protected:
+  // return the path from the local game directory to the local saves folder
+  //
+  // this is virtual so game plugins for complete game overhauld (Enderal, Nehrim, etc.)
+  // can override it properly
+  //
+  virtual QString localSavesDummy() const;
+
   QDir localSavesDirectory() const;
   QDir localGameDirectory() const;
 

--- a/src/gamebryo/gamebryolocalsavegames.h
+++ b/src/gamebryo/gamebryolocalsavegames.h
@@ -24,18 +24,23 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <QDir>
 #include <QString>
 
+class GameGamebryo;
+
 class GamebryoLocalSavegames : public MOBase::LocalSavegames
 {
 
 public:
-  GamebryoLocalSavegames(const QDir& myGamesDir, const QString& iniFileName);
+  GamebryoLocalSavegames(const GameGamebryo* game, const QString& iniFileName);
 
   virtual MappingType mappings(const QDir& profileSaveDir) const override;
   virtual bool prepareProfile(MOBase::IProfile* profile) override;
 
+protected:
+  QDir localSavesDirectory() const;
+  QDir localGameDirectory() const;
+
 private:
-  QDir m_LocalSavesDir;
-  QDir m_LocalGameDir;
+  const GameGamebryo* m_Game;
   QString m_IniFileName;
 };
 

--- a/src/gamebryo/gamegamebryo.cpp
+++ b/src/gamebryo/gamegamebryo.cpp
@@ -83,7 +83,7 @@ QDir GameGamebryo::documentsDirectory() const
 
 QDir GameGamebryo::savesDirectory() const
 {
-  return QDir(m_MyGamesPath + "/Saves");
+  return QDir(myGamesPath() + "/Saves");
 }
 
 std::vector<std::shared_ptr<const MOBase::ISaveGame>>

--- a/src/gamebryo/gamegamebryo.h
+++ b/src/gamebryo/gamegamebryo.h
@@ -85,6 +85,9 @@ public:  // IPluginGame interface
 public:  // IPluginFileMapper interface
   virtual MappingType mappings() const;
 
+public:  // Other (e.g. for game features)
+  QString myGamesPath() const;
+
 protected:
   // Retrieve the saves extension for the game.
   virtual QString savegameExtension() const   = 0;
@@ -95,7 +98,6 @@ protected:
   makeSaveGame(QString filepath) const = 0;
 
   QFileInfo findInGameFolder(const QString& relativePath) const;
-  QString myGamesPath() const;
   QString selectedVariant() const;
   WORD getArch(QString const& program) const;
 


### PR DESCRIPTION
PRs for the various games are needed (WIP).

This should fix the crash on startup when that was due to `setGamePath` called in some game plugins that register some features due to a change in `myGamesPath`. The fix is to not pass `myGamesPath()` to game feature at initializing but rather the game plugin itself and access `myGamesPath()` when needed.